### PR TITLE
Kalender auch auf Handy ansehbar machen

### DIFF
--- a/src/components/Calendar/Calendar.vue
+++ b/src/components/Calendar/Calendar.vue
@@ -532,6 +532,7 @@ export default {
 .content {
 	.calendar {
 		max-width: 100%;
+		overflow: scroll;
 
 		table {
 			line-height: 1.5;


### PR DESCRIPTION
Einfach immer den Kalender scrollbar machen.